### PR TITLE
Convert JSON strings to maps to fix flaky test behavior

### DIFF
--- a/server/src/test/java/com/cloud/server/StatsCollectorTest.java
+++ b/server/src/test/java/com/cloud/server/StatsCollectorTest.java
@@ -62,6 +62,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.when;
@@ -330,7 +331,7 @@ public class StatsCollectorTest {
         VmStatsVO actual = vmStatsVOCaptor.getAllValues().get(0);
         Assert.assertEquals(Long.valueOf(2L), actual.getVmId());
         Assert.assertEquals(Long.valueOf(1L), actual.getMgmtServerId());
-        Assert.assertEquals(expectedVmStatsStr, actual.getVmStatsData());
+        Assert.assertEquals(convertJsonToOrderedMap(expectedVmStatsStr), convertJsonToOrderedMap(actual.getVmStatsData()));
         Assert.assertEquals(timestamp, actual.getTimestamp());
     }
 
@@ -510,5 +511,15 @@ public class StatsCollectorTest {
     @Test
     public void testPersistVolumeStatsVmware() {
         performPersistVolumeStatsTest(Hypervisor.HypervisorType.VMware);
+    }
+
+    private Map<String, String> convertJsonToOrderedMap(String json) {
+        Map<String, String> jsonMap = new TreeMap<String, String>();
+        String[] keyValuePairs = json.replace("{", "").replace("}","").split(",");
+        for (String pair: keyValuePairs) {
+            String[] keyValue = pair.split(":");
+            jsonMap.put(keyValue[0], keyValue[1]);
+        }
+        return jsonMap;
     }
 }


### PR DESCRIPTION
The PR fixes the following test which produces non-deterministic/flaky output
`com.cloud.server.StatsCollectorTest.java#persistVirtualMachineStatsTestPersistsSuccessfully`

### Setup:

Java version: 11.0.20.1  
Maven version: 3.8.8   

### Test failure reproduction:  
The test `com.cloud.server.StatsCollectorTest.java#persistVirtualMachineStatsTestPersistsSuccessfully` compares two JSON Strings and asserts if they are equal. However, the order of key value pairs is not guaranteed in a JSON string. Hence the test can fail. This issue was verified using the [NonDex plugin](https://github.com/TestingResearchIllinois/NonDex). 

#### Steps:
```
git clone https://github.com/apache/cloudstack.git
cd cloudstack
mvn install -pl server -am -DskipTests
mvn -pl server edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cloud.server.StatsCollectorTest.java#persistVirtualMachineStatsTestPersistsSuccessfully
mvn -pl server edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cloud.server.StatsCollectorTest.java#persistVirtualMachineStatsTestPersistsSuccessfully -DnondexMode=ONE
```

### Root cause and Fix
Test Failure in Nondex Mode
```
Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   StatsCollectorTest.persistVirtualMachineStatsTestPersistsSuccessfully:335 expected:<{"vmId":2,"[cpuUtilization":6.0,"networkReadKBs":7.0,"networkWriteKBs":8.0,"diskReadIOs":12.0,"diskWriteIOs":13.0,"diskReadKBs":10.0,"diskWriteKBs":11.0,"memoryKBs":3.0,"intFreeMemoryKBs":4.0,"targetMemoryKBs":5.0,"numCPUs":9,"entityType":"vm"]}> but was:<{"vmId":2,"[networkWriteKBs":8.0,"memoryKBs":3.0,"entityType":"vm","cpuUtilization":6.0,"diskReadKBs":10.0,"networkReadKBs":7.0,"diskReadIOs":12.0,"targetMemoryKBs":5.0,"numCPUs":9,"intFreeMemoryKBs":4.0,"diskWriteIOs":13.0,"diskWriteKBs":11.0]}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
The following error occurs when comparing two json strings in this [line](https://github.com/apache/cloudstack/blob/99ded8169beef89a664df7580b2f039569491172/server/src/test/java/com/cloud/server/StatsCollectorTest.java#L333). The expected string is a hardcoded json string. The actual string is obtained by converting the class attributes to JSON(using the Gson library) [here](https://github.com/apache/cloudstack/blob/99ded8169beef89a664df7580b2f039569491172/server/src/main/java/com/cloud/server/StatsCollector.java#L1900). The comparision fails in some cases since the key orderings between the JSON data could be different. 


### Fix
The Fix converts both the JSON strings to TreeMaps(which maintain key order) and compares these for equality. 

### Verification of fix
- The test passes when run with the NonDex tool. 
- The entire test suite of the module passes.
