### PR TITLE
Fix flaky tungsten test using comparator

### DIFF
--- a/plugins/network-elements/tungsten/src/test/java/org/apache/cloudstack/network/tungsten/service/TungstenApiTest.java
+++ b/plugins/network-elements/tungsten/src/test/java/org/apache/cloudstack/network/tungsten/service/TungstenApiTest.java
@@ -1360,6 +1360,7 @@ public class TungstenApiTest {
 
         s_logger.debug("Check if policy was listed all in Tungsten-Fabric");
         List<? extends ApiObjectBase> policyList3 = tungstenApi.listTungstenPolicy(projectUuid, null);
+        policyList3.sort(comparator);
         assertEquals(policyList1, policyList3);
 
         s_logger.debug("Check if policy was listed with uuid in Tungsten-Fabric");
@@ -1383,6 +1384,7 @@ public class TungstenApiTest {
 
         s_logger.debug("Check if network was listed all in Tungsten-Fabric");
         List<? extends ApiObjectBase> networkList3 = tungstenApi.listTungstenNetwork(projectUuid, null);
+        networkList3.sort(comparator);
         assertEquals(networkList1, networkList3);
 
         s_logger.debug("Check if network policy was listed with uuid in Tungsten-Fabric");


### PR DESCRIPTION
### Description

This PR fixes the non deterministic behaviour of 2 tests. This happens as the tests assume the return value of an API to be ordered when it is actually not guaranteed. This has been detected using [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

### Reproduction of issue
1. `mvn install -pl plugins/network-elements/tungsten`
2. `mvn -pl plugins/network-elements/tungsten edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.cloudstack.network.tungsten.service.TungstenApiTest#listTungstenNetworkTest -DnondexMode=ONE`

Failure log:
```
[INFO] Running org.apache.cloudstack.network.tungsten.service.TungstenApiTest
[ERROR] Tests run: 77, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 1.35 s <<< FAILURE! - in org.apache.cloudstack.network.tungsten.service.TungstenApiTest
[ERROR] listTungstenNetworkTest(org.apache.cloudstack.network.tungsten.service.TungstenApiTest)  Time elapsed: 0.007 s  <<< FAILURE!
java.lang.AssertionError: expected:<[net.juniper.tungsten.api.types.VirtualNetwork@6bab2585, net.juniper.tungsten.api.types.VirtualNetwork@74bdc168]> but was:<[net.juniper.tungsten.api.types.VirtualNetwork@74bdc168, net.juniper.tungsten.api.types.VirtualNetwork@6bab2585]>
	at org.apache.cloudstack.network.tungsten.service.TungstenApiTest.listTungstenNetworkTest(TungstenApiTest.java:1387)

[ERROR] listTungstenPolicyTest(org.apache.cloudstack.network.tungsten.service.TungstenApiTest)  Time elapsed: 0.002 s  <<< FAILURE!
java.lang.AssertionError: expected:<[net.juniper.tungsten.api.types.NetworkPolicy@59aa20b3, net.juniper.tungsten.api.types.NetworkPolicy@363f6148]> but was:<[net.juniper.tungsten.api.types.NetworkPolicy@363f6148, net.juniper.tungsten.api.types.NetworkPolicy@59aa20b3]>
	at org.apache.cloudstack.network.tungsten.service.TungstenApiTest.listTungstenPolicyTest(TungstenApiTest.java:1363)
```

### Root cause
The test class `org.apache.cloudstack.network.tungsten.service.TungstenApiTest` uses [ApiConnectorMock](https://github.com/apache/cloudstack/blob/05b9b6e2e77b9b633f0fe22aff5f9f3c047b2303/plugins/network-elements/tungsten/src/test/java/org/apache/cloudstack/network/tungsten/service/TungstenApiTest.java#L98) for all tests. The tests `listTungstenNetworkTest`, `listTungstenPolicyTest` use the `list` method of this connector [Tungsten API connector call](https://github.com/apache/cloudstack/blob/main/plugins/network-elements/tungsten/src/main/java/org/apache/cloudstack/network/tungsten/service/TungstenApi.java#L2065) in their respective [tests](https://github.com/apache/cloudstack/blob/05b9b6e2e77b9b633f0fe22aff5f9f3c047b2303/plugins/network-elements/tungsten/src/test/java/org/apache/cloudstack/network/tungsten/service/TungstenApiTest.java#L1362-L1385).
 
The 3rd party library [juniper-tungsten-api](https://github.com/radu-todirica/tungsten-api/tree/master/net/juniper/tungsten/juniper-tungsten-api/2.0)'s `net.juniper.tungsten.api.ApiConnectorMock`'s `list` method does guarantee the ordering of results. Unfortunately, the source code is not on github for direct inspection. Upon downloading and decompiling the `juniper-tungsten-api-2.0.jar`, it can be seen that this method uses `HashMap.values()` which is unordered, for the population of the returned list. A screenshot has been added below. Decompilation was done using [Java-decompiler](http://www.javadecompilers.com). 

![image](https://github.com/rRajivramachandran/cloudstack/assets/22187598/a3d2e4dc-fead-4d29-aa10-b6adfbea9eb4)


### Fix
The test class already defines a comparator to sort objects of `ApiObjectBase` [here](https://github.com/apache/cloudstack/blob/main/plugins/network-elements/tungsten/src/test/java/org/apache/cloudstack/network/tungsten/service/TungstenApiTest.java#L93). This has been used to ensure consistent test behaviour.



### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial


### Screenshots (if appropriate):


### How Has This Been Tested?
- All tests in the test class pass(`mvn -pl plugins/network-elements/tungsten test -Dtest=org.apache.cloudstack.network.tungsten.service.TungstenApiTest`)
- All tests in test class pass when run with nondex(`mvn -pl plugins/network-elements/tungsten edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.cloudstack.network.tungsten.service.TungstenApiTest`)

#### How did you try to break this feature and the system with this change?

The change only touches test files and not source code. Hence it will not affect production. Test behavior consistency has also been verified 
